### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Xcloud87/70267557-6168-4a22-a986-a3b9defbd90f/c400f116-0d17-4025-beef-f476e7ac89fa/_apis/work/boardbadge/ec958915-180b-4dbb-9d91-d38caa7901b0)](https://dev.azure.com/Xcloud87/70267557-6168-4a22-a986-a3b9defbd90f/_boards/board/t/c400f116-0d17-4025-beef-f476e7ac89fa/Microsoft.RequirementCategory)
 [![Build Status](https://travis-ci.com/OfficeDev/script-lab.svg?token=paK2s5RGiCpVHK6bYoFs&branch=master)](https://travis-ci.com/OfficeDev/script-lab) [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier) [![tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
 
 # Script Lab, a Microsoft Garage project


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Xcloud87/70267557-6168-4a22-a986-a3b9defbd90f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.